### PR TITLE
wasix rust installation docs += `cargo wasix build ` required for toolchain to be installed.

### DIFF
--- a/pages/docs/language-guide/rust/installation.mdx
+++ b/pages/docs/language-guide/rust/installation.mdx
@@ -33,6 +33,7 @@ cargo-wasix 0.1.17
 Check that the `wasix` toolchain was installed correctly by running:
 
 ```shell
+# may require first `cargo wasix build` e.g.: cargo new xx; cd xx; cargo wasix build
 $ rustup toolchain list | grep wasix
 wasix
 ```


### PR DESCRIPTION
wasix rust installation docs += `cargo wasix build ` required for toolchain to be installed.